### PR TITLE
Fix/urls resolution

### DIFF
--- a/src/main/java/danta/jahia/Constants.java
+++ b/src/main/java/danta/jahia/Constants.java
@@ -34,9 +34,6 @@ import static org.apache.jackrabbit.spi.Name.*;
  */
 public class Constants {
 
-    public static final String PATH_DETAILS_LIST_PATH_PROPERTY_NAME = "path";
-    public static final String PATH_DETAILS_LIST_PATHS_PROPERTY_NAME = "paths";
-
     public static final String JAHIA_RENDER_CONTEXT = "jahiaRenderContext";
     public static final String JAHIA_RESOURCE = "jahiaResource";
     public static final String JAHIA_SCRIPT_VIEW = "jahiaScriptView";
@@ -57,8 +54,6 @@ public class Constants {
     public static final String IS_PREVIEW_MODE = "jahia_preview_mode";
     public static final String IS_LIVE_MODE = "jahia_live_mode";
     public static final String IS_AJAX_REQUEST = "jahia_is_ajax_request";
-    public static final String LIVE_WORKSPACE = "live";
-    public static final String DEFAULT_WORKSPACE = "default";
     public static final String JAHIA_WORKSPACE = "workspace";
 
     // Jahia Default Properties Page
@@ -128,5 +123,8 @@ public class Constants {
 
     // Web services
     public static final String SERVER_RESPONSE_CONTENT_TYPE = "application/json; charset=utf-8";
+
+    // Generic
+    public static final String HTML_EXT = ".html";
 
 }

--- a/src/main/java/danta/jahia/contextprocessors/AddAllResourceContentPropertiesContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/AddAllResourceContentPropertiesContextProcessor.java
@@ -24,10 +24,12 @@ import danta.api.ExecutionContext;
 import danta.api.exceptions.ProcessException;
 import danta.core.contextprocessors.AbstractCheckComponentCategoryContextProcessor;
 import danta.jahia.templating.TemplateContentModel;
+import danta.jahia.util.PropertyUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
+import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +41,10 @@ import java.util.Set;
 
 import static danta.Constants.*;
 import static danta.core.Constants.XK_CONTENT_ID_CP;
+import static danta.jahia.Constants.JAHIA_RENDER_CONTEXT;
 import static danta.jahia.Constants.JAHIA_RESOURCE;
 import static danta.jahia.Constants.JCR_NODE_UUID;
-import static danta.jahia.util.PropertyUtils.propsToMap;
+import danta.jahia.util.PropertyUtils;
 
 /**
  * The context processor for adding resource content properties to content model
@@ -73,13 +76,15 @@ public class AddAllResourceContentPropertiesContextProcessor
         try {
             Map<String, Object> content = new HashMap<>();
             Resource resource = (Resource) executionContext.get(JAHIA_RESOURCE);
+            RenderContext renderContext = (RenderContext) executionContext.get(JAHIA_RENDER_CONTEXT);
 
             if (resource != null) {
                 Node node = resource.getNode();
                 if (node != null) {
                     String componentContentId = DigestUtils.md5Hex(resource.getPath());
                     content.put(XK_CONTENT_ID_CP, componentContentId);
-                    Map<String, Object> propsMap = propsToMap(node.getProperties());
+                    Map<String, Object> propsMap = PropertyUtils.propsToMap(
+                            node.getProperties(), renderContext, resource);
                     for (String propertyName : propsMap.keySet()) {
                         if (!StringUtils.startsWithAny(propertyName, RESERVED_SYSTEM_NAME_PREFIXES)) {
                             content.put(propertyName, propsMap.get(propertyName));

--- a/src/main/java/danta/jahia/contextprocessors/AddGlobalPropertiesContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/AddGlobalPropertiesContextProcessor.java
@@ -84,7 +84,7 @@ public class AddGlobalPropertiesContextProcessor  extends AbstractCheckComponent
                     if (dantaNode != null && dantaNode.hasNode(LAYERX_CONFIGURATION_GLOBAL_NODE_NAME)) {
 
                         JCRNodeWrapper globalPropertiesNode = dantaNode.getNode(LAYERX_CONFIGURATION_GLOBAL_NODE_NAME);
-                        Map globalContext = processNode(globalPropertiesNode);
+                        Map globalContext = processNode(globalPropertiesNode, renderContext, resource);
                         contentModel.set(GLOBAL_PROPERTIES_KEY , globalContext);
 
                     } else {
@@ -99,7 +99,7 @@ public class AddGlobalPropertiesContextProcessor  extends AbstractCheckComponent
         }
     }
 
-    protected Map processNode(JCRNodeWrapper node)throws Exception{
+    protected Map processNode(JCRNodeWrapper node, RenderContext renderContext, Resource resource)throws Exception{
         if (node.hasNodes()){
             // Start a new level
             LinkedHashMap level = new LinkedHashMap();
@@ -107,18 +107,20 @@ public class AddGlobalPropertiesContextProcessor  extends AbstractCheckComponent
             Iterator<JCRNodeWrapper> iterator = node.getNodes().iterator();
             while( iterator.hasNext()){
                 JCRNodeWrapper childNode = iterator.next();
-                level.put(childNode.getName(), this.processNode(childNode));
+                level.put(childNode.getName(), this.processNode(childNode, renderContext, resource));
             }
 
             // Add current node properties (if any)
-            Map<String, Object> currentProperties = PropertyUtils.propsToMap(node);
+            Map<String, Object> currentProperties = PropertyUtils.propsToMap(
+                    node.getProperties(), renderContext, resource);
             level.putAll(currentProperties);
 
             return level;
 
         } else {
             // Leaf node reached
-            Map<String, Object> properties = PropertyUtils.propsToMap(node);
+            Map<String, Object> properties = PropertyUtils.propsToMap(
+                    node.getProperties(), renderContext, resource);
 
             return properties;
         }

--- a/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -85,7 +85,10 @@ public class AddPagePropertiesContextProcessor extends AbstractCheckComponentCat
                     if (mainResource != null) {
                         JCRNodeWrapper mainNode = mainResource.getNode();
 
-                        Map<String, Object> propsMap = propsToMap(mainNode.getProperties());
+                        Map<String, Object> propsMap = propsToMap(
+                                mainNode.getProperties(),
+                                renderContext,
+                                resource);
                         for (String propertyName : propsMap.keySet()) {
                             if (!StringUtils.startsWithAny(propertyName, RESERVED_SYSTEM_NAME_PREFIXES)) {
                                 pageContent.put(propertyName, propsMap.get(propertyName));
@@ -141,7 +144,10 @@ public class AddPagePropertiesContextProcessor extends AbstractCheckComponentCat
                                 Node pagesPropertiesNode = dantaNode.getNode(LAYERX_CONFIGURATION_PAGE_NODE_NAME);
                                 Node pageProperties = this.getPagePropertiesNode(pagesPropertiesNode, mainNode.getPath() );
                                 if (pageProperties != null){
-                                    Map<String, Object> propsMapPage = propsToMap(pageProperties);
+                                    Map<String, Object> propsMapPage = propsToMap(
+                                            pageProperties.getProperties(),
+                                            renderContext,
+                                            resource);
                                     pageContent.putAll(propsMapPage);
                                 }else{
                                     LOG.error("Page Properties node not found For Path: " + mainNode.getPath() );

--- a/src/main/java/danta/jahia/util/PropertyUtils.java
+++ b/src/main/java/danta/jahia/util/PropertyUtils.java
@@ -105,10 +105,10 @@ public class PropertyUtils {
      * @param property A property holding weak references
      * @param renderContext A renderContext object
      * @param resource A resource object
-     * @return content An object containing weak references tralsated into valid URLs
+     * @return content An object containing weak references translated into valid URLs
      * @throws RepositoryException
      */
-    public static Object resolve(Property property, RenderContext renderContext, Resource resource)
+    public static Object resolveReference(Property property, RenderContext renderContext, Resource resource)
         throws RepositoryException {
             Object resolvedValue;
 
@@ -210,7 +210,7 @@ public class PropertyUtils {
             if (ignoreSystemNames && StringUtils.startsWithAny(propertyName, RESERVED_SYSTEM_NAME_PREFIXES))
                 continue;
             if (property.getType() == (PropertyType.WEAKREFERENCE)) {
-                content.put(propertyName, resolve(property, renderContext, resource));
+                content.put(propertyName, resolveReference(property, renderContext, resource));
             } else {
                 content.put(propertyName, distill(property));
             }

--- a/src/main/java/danta/jahia/util/PropertyUtils.java
+++ b/src/main/java/danta/jahia/util/PropertyUtils.java
@@ -99,6 +99,15 @@ public class PropertyUtils {
         return content;
     }
 
+    /**
+     * Convert property to map
+     *
+     * @param property A property holding weak references
+     * @param renderContext A renderContext object
+     * @param resource A resource object
+     * @return content An object containing weak references tralsated into valid URLs
+     * @throws RepositoryException
+     */
     public static Object resolve(Property property, RenderContext renderContext, Resource resource)
         throws RepositoryException {
             Object resolvedValue;
@@ -167,6 +176,8 @@ public class PropertyUtils {
      * Takes an Iterator properties and turns it into map.
      *
      * @param properties This is an Iterator of Properties
+     * @param renderContext A renderContext object
+     * @param resource A resource object
      * @return map This is a list of Objects of Property
      * @throws Exception
      */
@@ -180,6 +191,9 @@ public class PropertyUtils {
      *
      * @param properties This is a list of Iterator Properties
      * @param ignoreSystemNames This is a boolean value to whether ignore system names
+     * @param renderContext A renderContext object
+     * @param resource A resource object
+     * @param ignoreSystemNames A boolean flag indicating if systems names should be ignored
      * @return content This is a list of Objects of Property
      * @throws Exception
      */

--- a/src/main/java/danta/jahia/util/ResourceUtils.java
+++ b/src/main/java/danta/jahia/util/ResourceUtils.java
@@ -74,6 +74,8 @@ public class ResourceUtils {
      *
      * @param session The session used to get resource node path
      * @param resourceNodeUUID The uuid used to get resource node path
+     * @param renderContext A renderContext object
+     * @param resource A resource object
      * @return resourceNodePath
      * @throws RepositoryException
      */

--- a/src/main/java/danta/jahia/util/ResourceUtils.java
+++ b/src/main/java/danta/jahia/util/ResourceUtils.java
@@ -31,6 +31,9 @@ import javax.jcr.Session;
 
 import java.util.Map;
 
+import static danta.Constants.HTML_EXT;
+import static danta.jahia.Constants.JAHIA_JNT_PAGE;
+
 /**
  * Resource utility class
  *
@@ -87,10 +90,10 @@ public class ResourceUtils {
                 URLGenerator urlGenerator = new URLGenerator(renderContext, resource);
                 String base = urlGenerator.getBase();
                 String nodeType = n.getPrimaryNodeType().getName();
-                if(nodeType.equals("jnt:page")) {
-                    resourcePath = base + n.getPath() + ".html";
+                if(nodeType.equals(JAHIA_JNT_PAGE)) {
+                    resourcePath = base + n.getPath() + HTML_EXT;
                 } else {
-                    resourcePath = base + n.getPath();
+                    resourcePath = ( (JCRNodeWrapper) n).getUrl();
                 }
 
             } catch (Exception e){
@@ -115,7 +118,7 @@ public class ResourceUtils {
         URLResolver urlResolver = urlResolverFactory.createURLResolver(url, renderContext);
         if(urlResolver != null) {
             path = urlResolver.getPath();
-            path = path.replace(".html", "");
+            path = path.replace(HTML_EXT, "");
         }
         return path;
     }


### PR DESCRIPTION
This is a fix for issue #15

The fix adds a new method for including node properties in the content model. In Jahia, since references to other resources (e.g., images and pages) are stored as unique identifiers, utility methods in the class _PropertyUtils_ translate these identifiers into string URLs. However, these methods do not generate the URLs properly as the _mode_ in the URLs (i.e., edit, render) was not always correct. This fix changes the way URLs are generated by considering the render context to generate the base of the URL first and concatenate the path of the resource.