### PR TITLE
Fix/upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
                     <instructions>
                         <Jahia-Module-Type>system</Jahia-Module-Type>
                         <Export-Package>danta.jahia.*, com.github.jknack.handlebars.*,com.github.jknack.* </Export-Package>
-                        <Import-Package>danta.core.util, danta.core.execution, javax.servlet.http,net.minidev.json;version=1.2.0, org.slf4j; version="[1.6, 2)"; resolution:=optional,
+                        <Import-Package>danta.core.util, danta.core.execution, javax.servlet.http,net.minidev.json;version=2.3.0, org.slf4j; version="[1.6, 2)"; resolution:=optional,
                             *,${jahia.plugin.projectPackageImport}
                         </Import-Package>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,12 @@
         <dependency>
             <groupId>Danta</groupId>
             <artifactId>API</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>Danta</groupId>
             <artifactId>Core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <!-- HANDLEBARS BEGIN -->
         <dependency>


### PR DESCRIPTION
This fix includes an update of the net.minidev.json to version 2.3.0.

This package is obtained from the Danta API bundle which embeds net.minidev.json.* under version 2.3.0. 
