### PR TITLE
Feature/update vanity url property

### DIFF
--- a/src/main/java/danta/jahia/Constants.java
+++ b/src/main/java/danta/jahia/Constants.java
@@ -91,6 +91,7 @@ public class Constants {
     public static final String JAHIA_JNT_CONTENT_TEMPLATE = "jnt:contentTemplate";
     public static final String JAHIA_JNT_CONTENT_LIST = "jnt:contentList";
     public static final String JAHIA_JNT_PAGE = "jnt:page";
+    public static final String JAHIA_VANITY_URL_MAPPING = "vanityUrlMapping";
 
     public static final String[] LIST_TEMPLATE_OPTION_TYPES = new String[]{
             JAHIA_JNT_TEMPLATE,

--- a/src/main/java/danta/jahia/Constants.java
+++ b/src/main/java/danta/jahia/Constants.java
@@ -92,6 +92,7 @@ public class Constants {
     public static final String JAHIA_JNT_CONTENT_LIST = "jnt:contentList";
     public static final String JAHIA_JNT_PAGE = "jnt:page";
     public static final String JAHIA_VANITY_URL_MAPPING = "vanityUrlMapping";
+    public static final String JAHIA_J_URL = "j:url";
 
     public static final String[] LIST_TEMPLATE_OPTION_TYPES = new String[]{
             JAHIA_JNT_TEMPLATE,

--- a/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -40,7 +40,7 @@ import static danta.Constants.*;
 import static danta.core.util.ObjectUtils.wrap;
 import static danta.jahia.Constants.*;
 import static danta.jahia.util.PropertyUtils.propsToMap;
-import static danta.jahia.util.PropertyUtils.getVanityURLs;
+import static danta.jahia.util.PageUtils.getVanityURLs;
 
 import static danta.jahia.Constants.RESERVED_SYSTEM_NAME_PREFIXES;
 

--- a/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -34,14 +34,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.*;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static danta.Constants.*;
 import static danta.core.util.ObjectUtils.wrap;
 import static danta.jahia.Constants.*;
 import static danta.jahia.util.PropertyUtils.propsToMap;
+import static danta.jahia.util.PropertyUtils.getVanityURLs;
 
 import static danta.jahia.Constants.RESERVED_SYSTEM_NAME_PREFIXES;
 
@@ -118,6 +117,12 @@ public class AddPagePropertiesContextProcessor extends AbstractCheckComponentCat
                         pageContent.put(IS_LIVE_MODE, renderContext.isLiveMode());
                         pageContent.put(IS_AJAX_REQUEST, renderContext.isAjaxRequest());
                         pageContent.put(JAHIA_WORKSPACE, renderContext.getWorkspace());
+
+                        // Adding vanity path (jnt:vanityUrls)
+                        Object vanityURLs = getVanityURLs(mainNode);
+                        if (vanityURLs != null) {
+                            pageContent.put(VANITY_PATH, vanityURLs);
+                        }
 
                         // Set Danta configuration for page resources only as it is obtained via the template
                         // associated to the view of the page (set by the script engine)

--- a/src/main/java/danta/jahia/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
@@ -37,7 +37,7 @@ import static danta.jahia.Constants.JAHIA_RESOURCE;
 import static danta.jahia.Constants.JCR_DESCRIPTION;
 import static danta.jahia.Constants.JCR_CREATED;
 import static danta.jahia.Constants.JCR_TITLE;
-import static danta.jahia.util.PropertyUtils.getVanityURLs;
+import static danta.jahia.util.PageUtils.getVanityURLs;
 
 /**
  * The abstraction for extracting page properties

--- a/src/main/java/danta/jahia/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
+++ b/src/main/java/danta/jahia/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
@@ -37,6 +37,7 @@ import static danta.jahia.Constants.JAHIA_RESOURCE;
 import static danta.jahia.Constants.JCR_DESCRIPTION;
 import static danta.jahia.Constants.JCR_CREATED;
 import static danta.jahia.Constants.JCR_TITLE;
+import static danta.jahia.util.PropertyUtils.getVanityURLs;
 
 /**
  * The abstraction for extracting page properties
@@ -63,10 +64,15 @@ public abstract class AbstractPageDetailsContextProcessor extends
             pageDetails.put(CREATED, ResourceUtils.getProperty(page, JCR_CREATED, ""));
             pageDetails.put(PAGE_TITLE,ResourceUtils.getProperty(page, JCR_TITLE, ""));
 
+            // Adding vanity path (jnt:vanityUrls)
+            Object vanityURLs = getVanityURLs(page);
+            if (vanityURLs != null) {
+                pageDetails.put(VANITY_PATH, vanityURLs);
+            }
+
             // This properties are not yet supported by Jahia UI for page properties
             pageDetails.put(SUBTITLE, ResourceUtils.getProperty(page, "", ""));
             pageDetails.put(NAVIGATION_TITLE, ResourceUtils.getProperty(page, "", ""));
-            pageDetails.put(VANITY_PATH, ResourceUtils.getProperty(page, "", ""));
 
             if (currentPage.equals(page.getPath())) {
                 pageDetails.put(IS_CURRENT_PAGE, true);

--- a/src/main/java/danta/jahia/util/PageUtils.java
+++ b/src/main/java/danta/jahia/util/PageUtils.java
@@ -1,0 +1,66 @@
+/**
+ * Danta AEM Bundle
+ *
+ * Copyright (C) 2017 Tikal Technologies, Inc. All rights reserved.
+ *
+ * Licensed under GNU Affero General Public License, Version v3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+ * without even the implied warranty of MERCHANTABILITY.
+ * See the License for more details.
+ */
+
+package danta.jahia.util;
+
+import org.jahia.services.content.JCRNodeWrapper;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static danta.jahia.Constants.JAHIA_VANITY_URL_MAPPING;
+
+/**
+ * Page Utility class, contained generic methods for handling a JahiaDF Page.
+ *
+ * @author      Danta Team
+ * @version     1.0.0
+ * @since       2018-01-17
+ */
+public class PageUtils {
+
+    /**
+     * Returns the vanity URL mappings stored under the page node.
+     *
+     * @param mainNode The page node
+     * @return vanityPaths The vanityURLs either as a string or list.
+     * @throws RepositoryException
+     */
+    public static Object getVanityURLs(JCRNodeWrapper mainNode) throws RepositoryException {
+        List vanityPaths = new ArrayList();
+        JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
+        if(vanityUrls != null) {
+            for (Node vanityUrl : vanityUrls.getNodes()) {
+                vanityPaths.add(vanityUrl.getName());
+            }
+        }
+        if(vanityPaths.size() > 0 ) {
+            if (vanityPaths.size() == 1) {
+
+                return vanityPaths.get(0);
+            } else {
+
+                return vanityPaths;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/danta/jahia/util/PageUtils.java
+++ b/src/main/java/danta/jahia/util/PageUtils.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static danta.jahia.Constants.JAHIA_VANITY_URL_MAPPING;
+import static danta.jahia.Constants.JAHIA_J_URL;
 
 /**
  * Page Utility class, contained generic methods for handling a JahiaDF Page.
@@ -41,25 +42,28 @@ public class PageUtils {
      *
      * @param mainNode The page node
      * @return vanityPaths The vanityURLs either as a string or list.
-     * @throws RepositoryException
      */
-    public static Object getVanityURLs(JCRNodeWrapper mainNode) throws RepositoryException {
+    public static Object getVanityURLs(JCRNodeWrapper mainNode) {
         List vanityPaths = new ArrayList();
-        JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
-        if(vanityUrls != null) {
-            for (Node vanityUrl : vanityUrls.getNodes()) {
-                vanityPaths.add(vanityUrl.getName());
-            }
-        }
-        if(vanityPaths.size() > 0 ) {
-            if (vanityPaths.size() == 1) {
+        try {
+            JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
 
-                return vanityPaths.get(0);
-            } else {
-
-                return vanityPaths;
+            if(vanityUrls != null) {
+                for (Node vanityUrl : vanityUrls.getNodes()) {
+                    vanityPaths.add(vanityUrl.getProperty(JAHIA_J_URL).getString());
+                }
             }
-        }
+            if(vanityPaths.size() > 0 ) {
+                if (vanityPaths.size() == 1) {
+
+                    return vanityPaths.get(0);
+                } else {
+
+                    return vanityPaths;
+                }
+            }
+        // Node might not exist or the structure in the JCR for storing vanity URLs might have changed in a newer version
+        } catch(RepositoryException e) { }
 
         return null;
     }

--- a/src/main/java/danta/jahia/util/PropertyUtils.java
+++ b/src/main/java/danta/jahia/util/PropertyUtils.java
@@ -29,14 +29,12 @@ import org.apache.commons.lang3.StringUtils;
 import javax.jcr.*;
 import java.util.*;
 
-import org.jahia.bin.Render;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static danta.Constants.VANITY_PATH;
 import static danta.jahia.Constants.JAHIA_VANITY_URL_MAPPING;
 import static danta.jahia.Constants.RESERVED_SYSTEM_NAME_PREFIXES;
 
@@ -442,7 +440,7 @@ public class PropertyUtils {
         List vanityPaths = new ArrayList();
         JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
         if(vanityUrls != null) {
-            for (javax.jcr.Node vanityUrl : vanityUrls.getNodes()) {
+            for (Node vanityUrl : vanityUrls.getNodes()) {
                 vanityPaths.add(vanityUrl.getName());
             }
         }

--- a/src/main/java/danta/jahia/util/PropertyUtils.java
+++ b/src/main/java/danta/jahia/util/PropertyUtils.java
@@ -30,11 +30,14 @@ import javax.jcr.*;
 import java.util.*;
 
 import org.jahia.bin.Render;
+import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static danta.Constants.VANITY_PATH;
+import static danta.jahia.Constants.JAHIA_VANITY_URL_MAPPING;
 import static danta.jahia.Constants.RESERVED_SYSTEM_NAME_PREFIXES;
 
 /**
@@ -428,5 +431,31 @@ public class PropertyUtils {
         return null;
     }
 
+    /**
+     * Returns the vanity URLs mapping stored under a page node in the JCR.
+     *
+     * @param mainNode The page node parameter
+     * @return vanityPaths The vanityURLs either as a single object or as an array list.
+     * @throws RepositoryException
+     */
+    public static Object getVanityURLs(JCRNodeWrapper mainNode) throws RepositoryException {
+        List vanityPaths = new ArrayList();
+        JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
+        if(vanityUrls != null) {
+            for (javax.jcr.Node vanityUrl : vanityUrls.getNodes()) {
+                vanityPaths.add(vanityUrl.getName());
+            }
+        }
+        if(vanityPaths.size() > 0 ) {
+            if (vanityPaths.size() == 1) {
 
+                return vanityPaths.get(0);
+            } else {
+
+                return vanityPaths;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/danta/jahia/util/PropertyUtils.java
+++ b/src/main/java/danta/jahia/util/PropertyUtils.java
@@ -428,32 +428,4 @@ public class PropertyUtils {
 
         return null;
     }
-
-    /**
-     * Returns the vanity URLs mapping stored under a page node in the JCR.
-     *
-     * @param mainNode The page node parameter
-     * @return vanityPaths The vanityURLs either as a single object or as an array list.
-     * @throws RepositoryException
-     */
-    public static Object getVanityURLs(JCRNodeWrapper mainNode) throws RepositoryException {
-        List vanityPaths = new ArrayList();
-        JCRNodeWrapper vanityUrls = mainNode.getNode(JAHIA_VANITY_URL_MAPPING);
-        if(vanityUrls != null) {
-            for (Node vanityUrl : vanityUrls.getNodes()) {
-                vanityPaths.add(vanityUrl.getName());
-            }
-        }
-        if(vanityPaths.size() > 0 ) {
-            if (vanityPaths.size() == 1) {
-
-                return vanityPaths.get(0);
-            } else {
-
-                return vanityPaths;
-            }
-        }
-
-        return null;
-    }
 }


### PR DESCRIPTION
Jahia allows multiple vanity URLs per page configurable in the SEO tag of the Page properties dialog. To preserve compatibility with AEM, if the vanity URLs property has only one element, then it is included as a single value in the content model. Otherwise, it is included as a list.